### PR TITLE
Force python-mode to use the same key-binding for commnet-region/comment...

### DIFF
--- a/init.el
+++ b/init.el
@@ -151,7 +151,8 @@
 (use-package python
   :ensure pungi
   :bind (("<kp-5>" . py-insert-debug)
-         ("<f9>" . py-insert-debug))
+         ("<f9>" . py-insert-debug)
+         ("C-c C-c" . comment-dwim))
   :config
   (progn
 	(setq python-check-command "pycheckers.py")


### PR DESCRIPTION
...-dwim as other major modes.

@adamcheasley @mattss  This makes commenting/un-commenting the same for python files
