### PR TITLE
remove hard coded line length limit

### DIFF
--- a/init.el
+++ b/init.el
@@ -145,7 +145,6 @@
   :config
   (setq flycheck-emacs-lisp-load-path 'inherit)
   (setq flycheck-python-flake8-executable "flake8")
-  (setq flycheck-flake8-maximum-line-length 79)
   (setq flycheck-highlighting-mode 'lines))
 
 (use-package flymake :disabled t)


### PR DESCRIPTION
This is the default in flake8 and also this will mean it can't be overridden on a per project basis.